### PR TITLE
Fix: Unexpected behavior of select option

### DIFF
--- a/src/features/px-rem/components/conversion-table.tsx
+++ b/src/features/px-rem/components/conversion-table.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from '@/ui/components/ui/select';
 
-import { MARGIN_OPTONS, PADDING_OPTIONS, PX_REM_CONVERSION } from '../data/px-rem';
+import { MARGIN_OPTIONS, PADDING_OPTIONS, PX_REM_CONVERSION } from '../data/px-rem';
 import { PX_REM_LANGUAGES } from '../languages/px-rem.lng';
 import { InfoTable } from './info-table';
 
@@ -32,11 +32,11 @@ const SECOND_HALF = PX_REM_CONVERSION.slice(PX_REM_CONVERSION.length / 2, PX_REM
  * @return {JSX.Element} the conversion tables.
  */
 export function ConversionTables(): JSX.Element {
-  const [selectOption, setSelectOption] = useState<'gap' | PxRemPaddingType | PxRemMarginType>('gap');
+  const [selectOption, setSelectOption] = useState<PxRemSelectOption>('gap');
 
   const { translate } = useLanguage();
 
-  function handleChange(value: 'gap' | PxRemPaddingType | PxRemMarginType) {
+  function handleChange(value: PxRemSelectOption) {
     setSelectOption(value);
   }
 
@@ -57,15 +57,15 @@ export function ConversionTables(): JSX.Element {
             {/* Padding */}
             <SelectLabel>Padding</SelectLabel>
             {PADDING_OPTIONS.map((option, index) => (
-              <SelectItem key={index} value={option}>
-                {option}
+              <SelectItem key={index} value={option.key}>
+                {option.key}
               </SelectItem>
             ))}
             {/* Margin */}
             <SelectLabel>Margin</SelectLabel>
-            {MARGIN_OPTONS.map((option, index) => (
-              <SelectItem key={index} value={option}>
-                {option}
+            {MARGIN_OPTIONS.map((option, index) => (
+              <SelectItem key={index} value={option.key}>
+                {option.key}
               </SelectItem>
             ))}
           </SelectGroup>

--- a/src/features/px-rem/components/info-table.tsx
+++ b/src/features/px-rem/components/info-table.tsx
@@ -15,6 +15,7 @@ import {
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from '@/ui/components/ui/table';
 
 import { PX_REM_LANGUAGES } from '../languages/px-rem.lng';
+import { mapSelectOption } from '../utils/mapSelectOption';
 
 // #endregion
 
@@ -24,7 +25,7 @@ interface InfoTableProps {
     rem: string;
     tailwind: string;
   }[];
-  selectOption: 'gap' | PxRemPaddingType | PxRemMarginType;
+  selectOption: PxRemSelectOption;
 }
 
 /**
@@ -79,10 +80,10 @@ export function InfoTable({ tableContent, selectOption = 'gap' }: InfoTableProps
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                  <DropdownMenuItem onClick={() => copySpacingValue(`gap: ${px}`)}>
+                  <DropdownMenuItem onClick={() => copySpacingValue(`${mapSelectOption(selectOption)}: ${px};`)}>
                     {translate('copy_px', PX_REM_LANGUAGES)}
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => copySpacingValue(`gap: ${rem}`)}>
+                  <DropdownMenuItem onClick={() => copySpacingValue(`${mapSelectOption(selectOption)}: ${rem};`)}>
                     {translate('copy_rem', PX_REM_LANGUAGES)}
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => copySpacingValue(`${selectOption}-${tailwind}`)}>

--- a/src/features/px-rem/data/px-rem.ts
+++ b/src/features/px-rem/data/px-rem.ts
@@ -39,6 +39,80 @@ export const PX_REM_CONVERSION: {
   { px: '384px', rem: '24rem', tailwind: '96' },
 ];
 
-export const PADDING_OPTIONS = ['p', 'px', 'py', 'ps', 'pe', 'pt', 'pr', 'pb', 'pl'];
+export const PADDING_OPTIONS = [
+  {
+    key: 'p',
+    value: 'padding',
+  },
+  {
+    key: 'px',
+    value: 'padding-inline',
+  },
+  {
+    key: 'py',
+    value: 'padding-block',
+  },
+  {
+    key: 'ps',
+    value: 'padding-start',
+  },
+  {
+    key: 'pe',
+    value: 'padding-end',
+  },
+  {
+    key: 'pt',
+    value: 'padding-top',
+  },
+  {
+    key: 'pr',
+    value: 'padding-right',
+  },
+  {
+    key: 'pb',
+    value: 'padding-bottom',
+  },
+  {
+    key: 'pl',
+    value: 'padding-left',
+  },
+];
 
-export const MARGIN_OPTONS = ['m', 'mx', 'my', 'ms', 'me', 'mt', 'mr', 'mb', 'ml'];
+export const MARGIN_OPTIONS = [
+  {
+    key: 'm',
+    value: 'margin',
+  },
+  {
+    key: 'mx',
+    value: 'margin-inline',
+  },
+  {
+    key: 'my',
+    value: 'margin-block',
+  },
+  {
+    key: 'ms',
+    value: 'margin-start',
+  },
+  {
+    key: 'me',
+    value: 'margin-end',
+  },
+  {
+    key: 'mt',
+    value: 'margin-top',
+  },
+  {
+    key: 'mr',
+    value: 'margin-right',
+  },
+  {
+    key: 'mb',
+    value: 'margin-bottom',
+  },
+  {
+    key: 'ml',
+    value: 'margin-left',
+  },
+];

--- a/src/features/px-rem/utils/mapSelectOption.ts
+++ b/src/features/px-rem/utils/mapSelectOption.ts
@@ -1,0 +1,18 @@
+import { PADDING_OPTIONS } from '../data/px-rem';
+import { MARGIN_OPTIONS } from '../data/px-rem';
+
+export function mapSelectOption(selectOption: PxRemSelectOption) {
+  const paddingOption = PADDING_OPTIONS.find((option) => option.key === selectOption);
+
+  if (paddingOption) {
+    return paddingOption.value;
+  }
+
+  const marginOption = MARGIN_OPTIONS.find((option) => option.key === selectOption);
+
+  if (marginOption) {
+    return marginOption.value;
+  }
+
+  return 'gap';
+}

--- a/src/types/px-rem.d.ts
+++ b/src/types/px-rem.d.ts
@@ -1,3 +1,5 @@
 type PxRemPaddingType = 'p' | 'px' | 'py' | 'ps' | 'pe' | 'pt' | 'pr' | 'pb' | 'pl';
 
 type PxRemMarginType = 'm' | 'mx' | 'my' | 'ms' | 'me' | 'mt' | 'mr' | 'mb' | 'ml';
+
+type PxRemSelectOption = 'gap' | PxRemPaddingType | PxRemMarginType;


### PR DESCRIPTION
The selectOption is not working as intended in the Px/Rem feature.

In the options "copy value in pixels" and "copy value in rem", instead of returning values like:

`padding-inline: 4px` or `margin-block: 2px`

Is always returning `gap: some value`. So I created a function called `mapSelectOption()` that maps the key selected by the user and return the correlated CSS property for the options "copy value in pixels" and "copy value in rem".